### PR TITLE
chore(ci): use action-deploy-plugin main

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -12,7 +12,7 @@ jobs:
     permissions: write-all
 
     steps:
-      - uses: ubiquity-os/action-deploy-plugin@feat/320-dist-artifact-branches
+      - uses: ubiquity-os/action-deploy-plugin@main
         with:
           action: ${{ github.event_name == 'delete' && 'delete' || 'publish' }}
           sourceRef: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary\n- switch update configuration workflow to `ubiquity-os/action-deploy-plugin@main`\n- keep artifact branch inputs (`sourceRef`, `artifactPrefix`) unchanged\n\nRelated to ubiquity-os/ubiquity-os-kernel#320