### PR TITLE
chore(ci): target main in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: simple
-          target-branch: ${{ github.ref_name }}
+          target-branch: main


### PR DESCRIPTION
## Summary
- set release-please `target-branch` to `main` explicitly
- keep trigger branches unchanged

Related to ubiquity-os/ubiquity-os-kernel#320
