### PR TITLE
fix(ci): rely on delete-aware action sourceRef defaults

### DIFF
--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -33,7 +33,6 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
         with:
-          sourceRef: ${{ github.event.ref || github.event.workflow_run.head_branch || github.ref_name }}
           artifactPrefix: dist/
           token: ${{ secrets.DENO_DEPLOY_TOKEN }}
           action: ${{ github.event_name == 'delete' && 'delete' || 'deploy' }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: ubiquity-os/action-deploy-plugin@main
         with:
           action: ${{ github.event_name == 'delete' && 'delete' || 'publish' }}
-          sourceRef: ${{ github.event.ref || github.ref_name }}
           artifactPrefix: dist/
           excludeSupportedEvents: "issue_comment.created"
         env:

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ubiquity-os/action-deploy-plugin@main
         with:
           action: ${{ github.event_name == 'delete' && 'delete' || 'publish' }}
-          sourceRef: ${{ github.ref_name }}
+          sourceRef: ${{ github.event.ref || github.ref_name }}
           artifactPrefix: dist/
           excludeSupportedEvents: "issue_comment.created"
         env:


### PR DESCRIPTION
## Summary
- remove explicit `sourceRef` inputs from `action-deploy-plugin` and `deno-deploy` workflow calls
- rely on action-level delete-aware defaults for source-branch resolution
- keep artifact branch prefix explicit as `dist/`

## Why
This avoids duplicating branch-resolution logic in every plugin workflow and centralizes delete handling in the actions.

## Dependency
- ubiquity-os/action-deploy-plugin#34
- ubiquity-os/deno-deploy#22

Closes ubiquity-os/ubiquity-os-kernel#320
